### PR TITLE
PKG-7533: scapy 2.6.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -61,7 +61,7 @@ about:
   license_file: LICENSE
   summary: 'Scapy: interactive packet manipulation tool'
   description: 'Scapy is a powerful Python-based interactive packet manipulation program and library.'
-  doc_url: https://scapy.readthedocs.io/en/latest/
+  doc_url: https://scapy.readthedocs.io
   dev_url: https://github.com/secdev/scapy
 
 extra:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -56,12 +56,12 @@ test:
 
 about:
   home: https://scapy.net
-  license: GPLv2
+  license: GPL-2.0-only
   license_family: GPL
   license_file: LICENSE
   summary: 'Scapy: interactive packet manipulation tool'
   description: 'Scapy is a powerful Python-based interactive packet manipulation program and library.'
-  doc_url: https://scapy.readthedocs.io
+  doc_url: https://scapy.readthedocs.io/en/latest/
   dev_url: https://github.com/secdev/scapy
 
 extra:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,25 +11,25 @@ source:
 
 build:
   number: 0
-  noarch: python
+  skip: True  # [py<37]
   entry_points:
     - scapy = scapy.main:interact
-    - UTscapy = scapy.tools.UTscapy:main
-  script: "python -m pip install . --no-deps --no-build-isolation -vv"
+  script: "{{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation"
 
 requirements:
   host:
     - pip
     - python
+    - wheel
+    - setuptools >=62.0.0
   run:
     - python
-    - ipython
-    - cryptography
-    - matplotlib
-run_constrained:
-  - cryptography >=2.0
+  run_constrained:
+    - cryptography >=2.0
 
 test:
+  requires:
+    - pip
   imports:
     - scapy
     - scapy.arch
@@ -52,18 +52,17 @@ test:
     - scapy.tools
   commands:
     - scapy -h
-    - UTscapy -h
+    - pip check
 
 about:
-  home: "https://scapy.net"
-  license: "GNU General Public v2 (GPLv2)"
-  license_family: "GPL2"
-  license_file: "LICENSE"
-  summary: "Scapy: interactive packet manipulation tool"
-  description: |
-    Scapy is a powerful Python-based interactive packet manipulation program and library.
-  doc_url: "https://scapy.readthedocs.io"
-  dev_url: "https://github.com/secdev/scapy"
+  home: https://scapy.net
+  license: GPLv2
+  license_family: GPL
+  license_file: LICENSE
+  summary: 'Scapy: interactive packet manipulation tool'
+  description: 'Scapy is a powerful Python-based interactive packet manipulation program and library.'
+  doc_url: https://scapy.readthedocs.io
+  dev_url: https://github.com/secdev/scapy
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "scapy" %}
-{% set version = "2.4.3rc2" %}
+{% set version = "2.6.1" %}
 
 package:
   name: "{{ name|lower }}"
@@ -7,15 +7,15 @@ package:
 
 source:
   url: "https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz"
-  sha256: "193da281a73d368b9f4b9b6b712bd3fee7ee40e07d69dfbe2763ecd409a064e6"
+  sha256: "7600d7e2383c853e5c3a6e05d37e17643beebf2b3e10d7914dffcc3bc3c6e6c5"
 
 build:
-  number: 1
+  number: 0
   noarch: python
   entry_points:
     - scapy = scapy.main:interact
     - UTscapy = scapy.tools.UTscapy:main
-  script: "{{ PYTHON }} -m pip install . --ignore-installed -vv "
+  script: "python -m pip install . --no-deps --no-build-isolation -vv"
 
 requirements:
   host:
@@ -26,6 +26,8 @@ requirements:
     - ipython
     - cryptography
     - matplotlib
+run_constrained:
+  - cryptography >=2.0
 
 test:
   imports:


### PR DESCRIPTION
scapy 2.6.1

**Destination channel:** defaults

### Links
- [PKG-7533](https://anaconda.atlassian.net/browse/PKG-7533) 
- dev_url: https://github.com/secdev/scapy/tree/v2.6.1
- conda_forge: https://github.com/conda-forge/scapy-feedstock
- pypi: https://pypi.org/project/scapy/2.6.1/
- pypi inspector: https://inspector.pypi.io/project/scapy/2.6.1/

### Explanation of changes:
- new version number

[PKG-7533]: https://anaconda.atlassian.net/browse/PKG-7533?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ